### PR TITLE
fixed bash error: run.sh: line 11: [: : unary operator expected

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,7 @@ start_superadmin() {
         /usr/bin/node --nouse-idle-notification --expose-gc /www/superadmin/release.js 9999 > /www/logs/superadmin.log &
 }
 
-if [ $SA_PID ]
+if [[ $SA_PID ]]
 then
         echo "KILLING OLD INSTANCE OF SUPERADMIN"
         kill -9 $SA_PID


### PR DESCRIPTION
When running `bash /www/superadmin/run.sh` this error appeared in debian stretch.

This is due to bash expecting all variables with quotes when using Posix-compatible single bracket version `[ ..  ]`
so another possibilty would be 
`if [ "$SA_PID" ]`
without the quotes, bash substitutes the variable to 
`if [  ]`
as can be seen in [here](https://stackoverflow.com/a/13618376).

Quoting rici from stackexchange:
> If you know you're always going to use bash, it's much easier to always use the double bracket conditional compound command [[ ... ]], instead of the Posix-compatible single bracket version [ ... ]. Inside a [[ ... ]] compound, word-splitting and pathname expansion are not applied to words,
[...]
If you use [ ... ], you always need to remember to double quote variables like this:
`if [ "$aug1" = "and" ];`
If you don't quote the variable expansion and the variable is undefined or empty, it vanishes from the scene of the crime, leaving only
`if [ = "and" ]; `
which is not a valid syntax. (It would also fail with a different error message if $aug1 included white space or shell metacharacters.)
The modern `[[` operator has lots of other nice features, including regular expression matching.