### PR TITLE
Replace base image with node:16-alpine

### DIFF
--- a/dockerfile.alpine
+++ b/dockerfile.alpine
@@ -1,0 +1,49 @@
+FROM node:16-alpine
+
+ENV domain=localhost
+
+RUN apk update && \
+    apk upgrade -U && \
+    apk add nginx graphicsmagick zip unzip lsof socat git acme.sh
+
+RUN rm -rf /var/cache/*
+
+# Configure and copy SuperAdmin directory
+WORKDIR /www
+RUN mkdir /www/logs/
+RUN mkdir /www/nginx/
+RUN mkdir /www/acme/
+RUN mkdir /www/ssl/
+RUN mkdir /www/www/
+RUN mkdir /www/superadmin/
+RUN mkdir /www/node_modules/
+RUN npm install total4
+RUN npm install total.js
+RUN npm install dbms
+ADD . /www/superadmin
+RUN echo "root:0:0" >> /www/superadmin/user.guid
+
+# Configure nginx
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY superadmin.conf /www/nginx/
+RUN sed -i s/#disablehttp#//g /www/nginx/superadmin.conf
+RUN sed -i s/#domain#/$domain/g /www/nginx/superadmin.conf
+
+EXPOSE 80 443 9999
+RUN ["chmod", "+x", "/www/superadmin/run-docker-alpine.sh"]
+CMD /www/superadmin/run-docker-alpine.sh
+
+#BUILDING IT
+#docker build -f dockerfile.alpine -t superadmin:3.0 .
+
+#BUILDING MULTIARCH WITH BUILDX
+#BOOTSTRAP: ## Start multicompiler
+# docker buildx inspect --bootstrap
+
+#BUILDX
+# docker buildx build --no-cache -f dockerfile.alpine \
+#	--platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7,linux/arm/v6 \
+#	-t superadmin:3.0 --pull --push .
+
+#RUN IT (you can also map any of the exposed ports above)
+#docker run -p 9999:9999 -it superadmin:3.0

--- a/run-docker-alpine.sh
+++ b/run-docker-alpine.sh
@@ -1,0 +1,2 @@
+node --nouse-idle-notification --expose-gc /www/superadmin/index.js 9999 --release > /dev/stdout &
+nginx -g "daemon off;"


### PR DESCRIPTION
I've created a new dockerfile with node:16-alpine as base image.
I've compiled it many architectures, would you mind if I publish those multi-arch images under my docker hub?